### PR TITLE
truncate

### DIFF
--- a/app/assets/stylesheets/rooms.scss
+++ b/app/assets/stylesheets/rooms.scss
@@ -242,6 +242,17 @@ p.kaiwa-text:last-child {
 .room-info{
   margin-left: 20px;
   margin-top: 20px;
+  padding-bottom: 10px;
+  padding-right: 15px;
+  word-wrap: break-word;
+}
+
+.room-info-1{
+  margin-left: 20px;
+  margin-top: 20px;
+  padding-bottom: 10px;
+  padding-right: 15px;
+  word-wrap: break-word;
 }
 
 .aaa{

--- a/app/views/clients/index.html.erb
+++ b/app/views/clients/index.html.erb
@@ -1,4 +1,4 @@
-<% @users.each do |f|%>
+<% @users.each do |f| %>
 	<div class="row">
 		<div class="user-list c-btn hover2">
 			<%= link_to client_path(f.id) do%>

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -24,7 +24,7 @@
       <div class="room-box">
         <%= link_to room_path(room) do %>
           <p>ルーム：<%= room.title %></p>
-          <p>内容：<%= room.detail %></p>
+          <p>内容：<%= truncate(room.detail, length: 20) %></p>
           <p>カテゴリ：<%= room.category %></p>
           <p>コメント数：<%= room.messages.count %>pt</p>
           <p style="float: left;">作成日：<%= room.created_at.strftime("%Y-%m-%d %H:%M") %></p>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -4,9 +4,11 @@
 			<div class="col-3">
 				<div class="aaa">
 					<h5 class="room-title">ルーム名</h5>
-					<p class="room-info"><%= @room.title %></p>
+					<p class="room-info-1"><%= @room.title %></p>
+				</div>
+				<div class="aaa">
 					<h5 class="room-title">内容</h5>
-					<p class="room-info"><%= @room.detail %></p>
+					<p class="room-info-1"><%= @room.detail %></p>
 				</div>
 			</div>
 			<div class="col-9">


### PR DESCRIPTION
・ルーム一覧のルーム説明文をtruncateにし、表示される文章量を20文字にした
・ルーム詳細の情報欄が折り返し出来ていなかったので修正した